### PR TITLE
Add options to customize registry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,20 @@ import type {Options, StoreRecord} from './types';
 
 //TODO: Account for non-latest releases
 
-const updater = async ( { name, version, ttl = 0 }: Options ): Promise<boolean> => {
+const updater = async ( {
+  authInfo,
+  name,
+  registryUrl,
+  version,
+  ttl = 0
+}: Options ): Promise<boolean> => {
 
   const record = Store.get ( name );
   const timestamp = Date.now ();
   const isFresh = !record || ( timestamp - record.timestampFetch ) >= ttl;
-  const latest = isFresh ? await Utils.getLatestVersion ( name ).catch ( Utils.noop ) : record?.version;
+  const latest = isFresh
+    ? await Utils.getLatestVersion ( name, { authInfo, registryUrl } ).catch ( Utils.noop )
+    : record?.version;
 
   if ( !latest ) return false;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,17 @@
 
 /* MAIN */
 
+type AuthInfo = {
+  type: string,
+  token: string
+};
+
 type Options = {
+  authInfo?: AuthInfo | undefined
   name: string,
+  registryUrl?: string | undefined,
   version: string,
-  ttl?: number
+  ttl?: number | undefined
 };
 
 type StoreRecord = {
@@ -13,6 +20,21 @@ type StoreRecord = {
   version: string
 };
 
+type UtilsFetchOptions = {
+  authInfo?: AuthInfo | undefined
+};
+
+type UtilsGetLatestVersionOptions = {
+  authInfo?: AuthInfo | undefined,
+  registryUrl?: string | undefined
+};
+
 /* EXPORT */
 
-export type {Options, StoreRecord};
+export type {
+  AuthInfo,
+  Options,
+  StoreRecord,
+  UtilsFetchOptions,
+  UtilsGetLatestVersionOptions
+};


### PR DESCRIPTION
Pr to add minimal options to customize the registry. This leaves the resolving of the token type, token, and registry to other libraries but allows it to be customized here as options.

Some libs used with this by others could be:
 * https://www.npmjs.com/package/registry-url
 * https://www.npmjs.com/package/registry-auth-token