### PR TITLE
chore: add doc comments to updater and options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,42 @@ import type {Options, StoreRecord} from './types';
 
 //TODO: Account for non-latest releases
 
+/**
+ * Checks and informs the user if there is an update available for the given package.
+ *
+ * @example
+ *
+ * The simplest way to use the library requires passing the `name` and `version` of
+ * your package. This will check and inform the user if there is an update available
+ * ever time it runs.
+ *
+ * ```js
+ * import {name, version} from './package.json';
+ * import updater from 'tiny-updater';
+ *
+ * await updater ({ name, version });
+ * ```
+ *
+ * @example
+ *
+ * You can optionally improve the user experience by providing a `ttl` (time-to-live)
+ * cache duration in milliseconds. This prevents the same update notification from
+ * being shown repeatedly by only checking for updates after the specified time has passed.
+ * This also improves performance by avoiding unnecessary HTTP requests to the npm registry.
+ *
+ * For example, with `ttl: 86_400_000` (24 hours), users will only see update notifications
+ * once per day, even if your application runs multiple times.
+
+ *
+ * ```js
+ * import {name, version} from './package.json';
+ * import updater from 'tiny-updater';
+ *
+ * await updater ({ name, version, ttl: 86_400_000 });
+ * ```
+ *
+ * @returns `true` if an update is available, `false` otherwise.
+ */
 const updater = async ( { name, version, ttl = 0 }: Options ): Promise<boolean> => {
 
   const record = Store.get ( name );

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,23 @@
 /* MAIN */
 
 type Options = {
+  /**
+   * The name of the package to check for.
+   */
   name: string,
+
+  /**
+   * The current version of the package.
+   */
   version: string,
+
+  /**
+   * Cache duration in milliseconds between update checks. When set, update
+   * notifications will only appear after this time has passed since the last check,
+   * preventing repeated notifications and reducing HTTP requests to the npm registry.
+   *
+   * @default 0
+   */
   ttl?: number
 };
 


### PR DESCRIPTION
This adds doc comments to `updater` and `Options` to improve DX.

[`tsex`](https://www.npmjs.com/package/tsex) doesn't seem to understand the comments, but it doesn't appear to effect the end result.

```bash
$ pnpm compile

> tiny-updater@3.5.3 compile /home/willow/dev/tiny-updater
> tsex compile

Failed to rewrite "./package.json" import in "/home/willow/dev/tiny-updater/dist/index.js"
Unknown dependency "tiny-updater", did you install it?
Failed to rewrite "./package.json" import in "/home/willow/dev/tiny-updater/dist/index.js"
Unknown dependency "tiny-updater", did you install it?
Failed to rewrite "./package.json" import in "/home/willow/dev/tiny-updater/dist/index.d.ts"
Unknown dependency "tiny-updater", did you install it?
Failed to rewrite "./package.json" import in "/home/willow/dev/tiny-updater/dist/index.d.ts"
Unknown dependency "tiny-updater", did you install it?
```

