### PR TITLE
Add `"sideEffects": false` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",,
+  "sideEffects": false,
   "scripts": {
     "clean": "tsex clean",
     "compile": "tsex compile",
@@ -35,6 +36,5 @@
     "fava": "^0.3.5",
     "tsex": "^4.0.2",
     "typescript": "^5.9.3"
-  },
-  "sideEffects": false
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,6 @@
     "fava": "^0.3.5",
     "tsex": "^4.0.2",
     "typescript": "^5.9.3"
-  }
+  },
+  "sideEffects": false
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "main": "dist/index.js",
   "exports": "./dist/index.js",
-  "types": "./dist/index.d.ts",,
+  "types": "./dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "clean": "tsex clean",


### PR DESCRIPTION
With this change, Prettier can tree-shake this unused module from the bundled CLI.